### PR TITLE
 Add a property test that validates the resulting index always equals the input index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language:  go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language:  go
 go:
-  - "1.11.x"
+  - 1.11.x
+
+script:
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language:  go
+go:
+  - "1.11.x"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# balancer
+[![Build Status](https://travis-ci.com/pdbrito/balancer.png?branch=master)](https://travis-ci.com/pdbrito/balancer) [![GoDoc](https://godoc.org/github.com/pdbrito/balancer?status.svg)](https://godoc.org/github.com/pdbrito/balancer) [![Go Report Card](https://goreportcard.com/badge/github.com/pdbrito/balancer)](https://goreportcard.com/report/github.com/pdbrito/balancer) [![Codecov](https://codecov.io/gh/pdbrito/balancer/branch/master/graphs/badge.svg)](https://codecov.io/gh/pdbrito/balancer/branch/master/)

--- a/balancer.go
+++ b/balancer.go
@@ -8,18 +8,23 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// An Asset is a string type used to identify your assets.
 type Asset string
 
+// A Holding represents a current quantity and value.
 type Holding struct {
 	Quantity decimal.Decimal
 	Value    decimal.Decimal
 }
 
+// A Trade represents a buy or sell action of a certain amount
 type Trade struct {
 	Action string
 	Amount decimal.Decimal
 }
 
+// Balance will return a map[Asset]Trade which will balance the passed in
+// holdings to match the passed in index.
 func Balance(holdings map[Asset]Holding, index map[Asset]decimal.Decimal) map[Asset]Trade {
 	//validate assumptions; only unique assets etc
 	totalHoldings := decimal.Zero

--- a/balancer.go
+++ b/balancer.go
@@ -1,3 +1,7 @@
+// Package balancer provides functionality to balance investment assets to a
+// target index. This is accomplished by calculating the current percentage
+// allocation of assets and then the trades necessary to match the specified
+// index.
 package balancer
 
 import (

--- a/balancer.go
+++ b/balancer.go
@@ -40,17 +40,13 @@ func Balance(holdings map[Asset]Holding, index map[Asset]decimal.Decimal) map[As
 				Mul(weight).
 				Div(holdings[asset].Value).
 				Sub(holdings[asset].Quantity)
-		trades[asset] = makeTrade(amountRequired)
+
+		if amountRequired.IsNegative() {
+			trades[asset] = Trade{"sell", amountRequired.Abs()}
+			continue
+		}
+		trades[asset] = Trade{"buy", amountRequired.Abs()}
 	}
 
 	return trades
-}
-func makeTrade(amount decimal.Decimal) Trade {
-	var action string
-	if amount.IsNegative() {
-		action = "sell"
-	} else {
-		action = "buy"
-	}
-	return Trade{action, amount.Abs()}
 }

--- a/balancer_quick_test.go
+++ b/balancer_quick_test.go
@@ -1,0 +1,92 @@
+package balancer_test
+
+import (
+	"fmt"
+	. "github.com/pdbrito/balancer"
+	"github.com/pdbrito/randomSum"
+	"github.com/shopspring/decimal"
+	"math/rand"
+	"strconv"
+	"testing"
+	"testing/quick"
+	"time"
+)
+
+func TestBalancer_ResultValueEqualToInput(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	f := func(n int) bool {
+		holdingsBefore := generateHoldingsNumbering(rand.Intn(8) + 2)
+		index := generateIndexForHoldings(holdingsBefore)
+
+		valueBefore := value(holdingsBefore)
+
+		trades := Balance(holdingsBefore, index)
+
+		holdingsAfter := execute(trades, holdingsBefore)
+
+		valueAfter := value(holdingsAfter)
+
+		sub := valueAfter.Sub(valueBefore)
+		fmt.Printf("difference: %v \n", sub)
+
+		return valueAfter.Equal(valueBefore)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func generateHoldingsNumbering(n int) map[Asset]Holding {
+	holdings := make(map[Asset]Holding)
+	for i := 0; i < n; i++ {
+		assetKey := strconv.Itoa(i)
+		holdings[Asset(assetKey)] = Holding{
+			Quantity: decimal.New(int64(rand.Intn(9)+1), 0),
+			Value:    decimal.New(int64(rand.Intn(9)+1), 0),
+		}
+	}
+	return holdings
+}
+
+func generateIndexForHoldings(holdings map[Asset]Holding) map[Asset]decimal.Decimal {
+	index := make(map[Asset]decimal.Decimal)
+
+	numberOfAssets := len(holdings)
+	indexValues := randomSum.NIntsTotaling(numberOfAssets, 100)
+
+	i := 0
+	for asset := range holdings {
+		index[asset] = decimal.New(int64(indexValues[i]), -2)
+		i++
+	}
+
+	return index
+}
+
+func value(holdings map[Asset]Holding) (sum decimal.Decimal) {
+	for _, holding := range holdings {
+		sum = sum.Add(holding.Quantity.Mul(holding.Value))
+	}
+	return sum
+}
+
+func execute(trades map[Asset]Trade, holdings map[Asset]Holding) map[Asset]Holding {
+	res := map[Asset]Holding{}
+
+	for asset, trade := range trades {
+
+		modifier := decimal.New(1, 0)
+		if trade.Action == "sell" {
+			modifier = decimal.New(-1, 0)
+		}
+
+		quantityAfterTrade := holdings[asset].Quantity.Add(trade.Amount.Mul(modifier))
+
+		res[asset] = Holding{
+			Quantity: quantityAfterTrade,
+			Value:    holdings[asset].Value,
+		}
+	}
+	return res
+}

--- a/balancer_quick_test.go
+++ b/balancer_quick_test.go
@@ -18,7 +18,7 @@ type fakeAccount struct {
 }
 
 func (f fakeAccount) Generate(rand *rand.Rand, size int) reflect.Value {
-	holdings := generateHoldingsNumbering(2)
+	holdings := generateHoldingsNumbering(rand.Intn(99) + 1)
 
 	return reflect.ValueOf(fakeAccount{
 		Holdings: holdings,
@@ -26,36 +26,50 @@ func (f fakeAccount) Generate(rand *rand.Rand, size int) reflect.Value {
 	})
 }
 
-func TestBalancer_ResultValueEqualToInput(t *testing.T) {
+func TestBalancer_ResultingIndexEqualToInputIndex(t *testing.T) {
 	assertion := func(f fakeAccount) bool {
-		valueBefore := value(f.Holdings)
-
 		trades := Balance(f.Holdings, f.Index)
 
 		holdingsAfter := execute(trades, f.Holdings)
-		valueAfter := value(holdingsAfter)
 
-		sub := valueAfter.Sub(valueBefore)
-		if !sub.Equal(decimal.Zero) {
-			fmt.Printf("Value before: %v \n", valueBefore)
-			fmt.Printf("Value after: %v \n", valueAfter)
-			fmt.Printf("difference: %v \n", sub)
-		}
+		indexAfter := calculateIndex(holdingsAfter)
 
-		return valueAfter.Equal(valueBefore)
+		return indexesAreEqual(f.Index, indexAfter)
 	}
+
 	if err := quick.Check(assertion, nil); err != nil {
 		if e, ok := err.(*quick.CheckError); ok {
 			for _, value := range e.In {
 				fa := value.(fakeAccount)
 				fmt.Printf("Holdings: %v\n", fa.Holdings)
-				fmt.Printf("Index: %v\n", fa.Index)
+				fmt.Printf("Desired index: %v\n", fa.Index)
 				fmt.Printf("Trades: %v\n", Balance(fa.Holdings, fa.Index))
 			}
 		}
 
 		t.Error(err)
 	}
+}
+
+func calculateIndex(holdings map[Asset]Holding) map[Asset]decimal.Decimal {
+	index := make(map[Asset]decimal.Decimal)
+	value := value(holdings)
+	for asset, holding := range holdings {
+		index[asset] = holding.Value.Mul(holding.Quantity).Div(value)
+	}
+	return index
+}
+
+func indexesAreEqual(i1, i2 map[Asset]decimal.Decimal) bool {
+	if len(i1) != len(i2) {
+		return false
+	}
+	for asset, amount := range i1 {
+		if amount2, ok := i2[asset]; !ok || !amount.Equal(amount2) {
+			return false
+		}
+	}
+	return true
 }
 
 func generateHoldingsNumbering(n int) map[Asset]Holding {

--- a/balancer_quick_test.go
+++ b/balancer_quick_test.go
@@ -37,6 +37,8 @@ func TestBalancer_ResultValueEqualToInput(t *testing.T) {
 
 		sub := valueAfter.Sub(valueBefore)
 		if !sub.Equal(decimal.Zero) {
+			fmt.Printf("Value before: %v \n", valueBefore)
+			fmt.Printf("Value after: %v \n", valueAfter)
 			fmt.Printf("difference: %v \n", sub)
 		}
 

--- a/balancer_quick_test.go
+++ b/balancer_quick_test.go
@@ -36,11 +36,22 @@ func TestBalancer_ResultValueEqualToInput(t *testing.T) {
 		valueAfter := value(holdingsAfter)
 
 		sub := valueAfter.Sub(valueBefore)
-		fmt.Printf("difference: %v \n", sub)
+		if !sub.Equal(decimal.Zero) {
+			fmt.Printf("difference: %v \n", sub)
+		}
 
 		return valueAfter.Equal(valueBefore)
 	}
 	if err := quick.Check(assertion, nil); err != nil {
+		if e, ok := err.(*quick.CheckError); ok {
+			for _, value := range e.In {
+				fa := value.(fakeAccount)
+				fmt.Printf("Holdings: %v\n", fa.Holdings)
+				fmt.Printf("Index: %v\n", fa.Index)
+				fmt.Printf("Trades: %v\n", Balance(fa.Holdings, fa.Index))
+			}
+		}
+
 		t.Error(err)
 	}
 }

--- a/balancer_quick_test.go
+++ b/balancer_quick_test.go
@@ -77,8 +77,8 @@ func generateHoldingsNumbering(n int) map[Asset]Holding {
 	for i := 0; i < n; i++ {
 		assetKey := strconv.Itoa(i)
 		holdings[Asset(assetKey)] = Holding{
-			Quantity: decimal.New(int64(rand.Intn(9)+1), 0),
-			Value:    decimal.New(int64(rand.Intn(9)+1), 0),
+			Quantity: decimal.NewFromFloat(rand.Float64() * 1000),
+			Value:    decimal.NewFromFloat(rand.Float64() * 1000),
 		}
 	}
 	return holdings

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -46,6 +46,7 @@ func assertSameTrades(t *testing.T, got map[Asset]Trade, want map[Asset]Trade) {
 		gotTrade, exists := got[asset]
 		if !exists {
 			t.Errorf("asset %s missing from trade list", asset)
+			return
 		}
 		if gotTrade.Action != wantTrade.Action {
 			t.Errorf(

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -8,24 +8,28 @@ import (
 
 func TestBalancer_Balance(t *testing.T) {
 	holdings := map[Asset]Holding{
-		"eth": {
+		"ETH": {
 			decimal.NewFromFloat(20),
 			decimal.NewFromFloat(200),
 		},
-		"btc": {
+		"BTC": {
 			decimal.NewFromFloat(0.5),
 			decimal.NewFromFloat(5000)},
 	}
 
 	index := map[Asset]decimal.Decimal{
-		"eth": decimal.NewFromFloat(0.3),
-		"btc": decimal.NewFromFloat(0.7),
+		"ETH": decimal.NewFromFloat(0.3),
+		"BTC": decimal.NewFromFloat(0.7),
 	}
 
 	got := Balance(holdings, index)
 	want := map[Asset]Trade{
-		"eth": {"sell", decimal.NewFromFloat(10.25)},
-		"btc": {"buy", decimal.NewFromFloat(0.41)},
+		"ETH": {"sell", decimal.NewFromFloat(10.25)},
+		"BTC": {"buy", decimal.NewFromFloat(0.41)},
+	}
+
+	assertSameTrades(t, got, want)
+}
 	}
 
 	assertSameTrades(t, got, want)
@@ -65,17 +69,17 @@ func assertSameTrades(t *testing.T, got map[Asset]Trade, want map[Asset]Trade) {
 func BenchmarkBalance(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		holdings := map[Asset]Holding{
-			"eth": {
+			"ETH": {
 				decimal.NewFromFloat(20),
 				decimal.NewFromFloat(200)},
-			"btc": {
+			"BTC": {
 				decimal.NewFromFloat(0.5),
 				decimal.NewFromFloat(5000),
 			},
 		}
 		index := map[Asset]decimal.Decimal{
-			"eth": decimal.NewFromFloat(0.3),
-			"btc": decimal.NewFromFloat(0.7),
+			"ETH": decimal.NewFromFloat(0.3),
+			"BTC": decimal.NewFromFloat(0.7),
 		}
 
 		_ = Balance(holdings, index)

--- a/balancer_test.go
+++ b/balancer_test.go
@@ -30,10 +30,6 @@ func TestBalancer_Balance(t *testing.T) {
 
 	assertSameTrades(t, got, want)
 }
-	}
-
-	assertSameTrades(t, got, want)
-}
 
 func assertSameTrades(t *testing.T, got map[Asset]Trade, want map[Asset]Trade) {
 	t.Helper()

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/pdbrito/balancer
 
-require github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
+require (
+	github.com/pdbrito/randomSum v0.0.0-20181209213857-cf25ad0ce9f1
+	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/pdbrito/randomSum v0.0.0-20181209213857-cf25ad0ce9f1 h1:qjBkATUWZbZDVMDs7ZIlYxRRvNGpTCclhxp8rTdp5N0=
+github.com/pdbrito/randomSum v0.0.0-20181209213857-cf25ad0ce9f1/go.mod h1:O0sg6WAIkp9vuG+sFMv4PXmbcHS6G+RJnV0963wGMTU=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 h1:pntxY8Ary0t43dCZ5dqY4YTJCObLY1kIXl0uzMv+7DE=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=


### PR DESCRIPTION
The Balance method currently returns a `map[Asset]Trade`. 

If we take these trades and apply them to the original holdings we have a new state of holdings.

If we then calculate the proportion of assets in this new state, it should match the proportion of assets passed into the balance function as the index.